### PR TITLE
Fix TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/craft-ai/most-utils/compare/v0.0.4...HEAD) ##
+### Changed ###
+- Update TypeScript definitions for all the packages
 
 ## [0.0.4](https://github.com/craft-ai/most-utils/compare/v0.0.3...v0.0.4) - 2017-08-07 ##
 ### Added ###
-- Typescript definitions for all the packages
+- TypeScript definitions for all the packages
 
 ## [0.0.3](https://github.com/craft-ai/most-utils/compare/v0.0.2...v0.0.3) - 2017-08-07 ##
 ### Added ###

--- a/packages/most-buffer/src/most-buffer.d.ts
+++ b/packages/most-buffer/src/most-buffer.d.ts
@@ -1,3 +1,3 @@
-import { Stream } from 'most'
+import { Stream } from 'most';
 
-declare function buffer<T>(count: number): (stream: Stream<T>) => Stream<T[]>;
+export default function buffer<T>(count: number): (stream: Stream<T>) => Stream<T[]>;

--- a/packages/most-limiter/src/most-limiter.d.ts
+++ b/packages/most-limiter/src/most-limiter.d.ts
@@ -1,3 +1,3 @@
-import { Stream } from 'most'
+import { Stream } from 'most';
 
-declare function limiter<T>(interval: number, capacity: number): (stream: Stream<T>) => Stream<T>;
+export default function limiter<T>(interval: number, capacity?: number): (stream: Stream<T>) => Stream<T>;


### PR DESCRIPTION
Changes:
- Fix missing default export
- Optional parameter `capacity` for `most-limiter`