### PR TITLE
Full stream buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/craft-ai/most-utils/compare/v0.0.6...HEAD) ##
+### Added ###
+- `most-buffer` - It is now possible to not provide the `count` argument to buffer the full stream.
 
 ## [0.0.6](https://github.com/craft-ai/most-utils/compare/v0.0.5...v0.0.6) - 2017-08-08 ##
 ### Changed ###

--- a/packages/most-buffer/README.md
+++ b/packages/most-buffer/README.md
@@ -29,9 +29,9 @@ stream:                 -a--b--c--------d--e--|
 stream.thru(buffer(3)): -------[a,b,c]--------[d,e]|
 ```
 
-- `count` is the size of the buffer
+- `count` is the size of the buffer, if undefined the full stream will be buffered before being emitted as an array.
 
-## Example ##
+## Examples ##
 
 ```js
 const most = require('most');
@@ -44,5 +44,14 @@ const buffer = require('most-buffer');
 most.iterate(x => x + 1, 0)
   .take(9) // 9 first numbers
   .thru(buffer(4)) // In buffer of 4 or less
+  .observe(x => console.log(x))
+```
+
+```js
+// Logs
+// [1, 2, 3, 4, 5, 6, 7, 8, 9]
+most.iterate(x => x + 1, 0)
+  .take(9) // 9 first numbers
+  .thru(buffer()) // Buffer the complete stream
   .observe(x => console.log(x))
 ```

--- a/packages/most-buffer/src/most-buffer.d.ts
+++ b/packages/most-buffer/src/most-buffer.d.ts
@@ -1,3 +1,3 @@
 import { Stream } from 'most';
 
-export default function buffer<T>(count: number): (stream: Stream<T>) => Stream<T[]>;
+export default function buffer<T>(count?: number): (stream: Stream<T>) => Stream<T[]>;

--- a/packages/most-buffer/src/most-buffer.js
+++ b/packages/most-buffer/src/most-buffer.js
@@ -9,8 +9,8 @@ class Buffer {
     // Buffering the new value
     this.buffer.push(value);
 
-    // If the buffer is full let's emit it
-    if (this.buffer.length === this.count) {
+    // If the buffer has a limit and is full, let's emit it
+    if (this.count && this.buffer.length === this.count) {
       this.sink.event(time, this.buffer);
       this.buffer = [];
     }
@@ -31,7 +31,7 @@ class Buffer {
   }
 }
 
-function buffer(count) {
+function buffer(count = undefined) {
   return stream => new stream.constructor({
     run: (sink, scheduler) => stream.source.run(new Buffer(count, sink), scheduler)
   });

--- a/packages/most-buffer/test/test-buffer.js
+++ b/packages/most-buffer/test/test-buffer.js
@@ -4,17 +4,33 @@ const most = require('most');
 
 describe('buffer', function() {
   it('can group stream events 10 by 10', function() {
+    let count = 0;
     return most.iterate(x => x + 1, 0)
-      .take(60)
+      .take(25)
       .thru(buffer(10))
+      .tap(() => { count += 1; })
       .tap(buffer => expect(buffer).to.have.lengthOf.at.most(10))
-      .drain();
+      .drain()
+      .then(() => expect(count).to.be.equal(3));
   });
   it('can group stream events 50 by 50', function() {
+    let count = 0;
     return most.iterate(x => x + 1, 0)
       .take(25)
       .thru(buffer(50))
-      .tap(buffer => expect(buffer).to.have.lengthOf.at.most(50))
-      .drain();
+      .tap(() => { count += 1; })
+      .tap(buffer => expect(buffer).to.have.lengthOf(25))
+      .drain()
+      .then(() => expect(count).to.be.equal(1));
+  });
+  it('wait for the source stream to be finished emitting anything when no count is given', function() {
+    let count = 0;
+    return most.iterate(x => x + 1, 0)
+      .take(25)
+      .thru(buffer())
+      .tap(() => { count += 1; })
+      .tap(buffer => expect(buffer).to.have.lengthOf(25))
+      .drain()
+      .then(() => expect(count).to.be.equal(1));
   });
 });

--- a/packages/most-buffer/test/test-buffer.js
+++ b/packages/most-buffer/test/test-buffer.js
@@ -4,33 +4,27 @@ const most = require('most');
 
 describe('buffer', function() {
   it('can group stream events 10 by 10', function() {
-    let count = 0;
     return most.iterate(x => x + 1, 0)
       .take(25)
       .thru(buffer(10))
-      .tap(() => { count += 1; })
       .tap(buffer => expect(buffer).to.have.lengthOf.at.most(10))
-      .drain()
-      .then(() => expect(count).to.be.equal(3));
+      .reduce(count => count + 1, 0)
+      .then(count => expect(count).to.be.equal(3));
   });
   it('can group stream events 50 by 50', function() {
-    let count = 0;
     return most.iterate(x => x + 1, 0)
       .take(25)
       .thru(buffer(50))
-      .tap(() => { count += 1; })
       .tap(buffer => expect(buffer).to.have.lengthOf(25))
-      .drain()
-      .then(() => expect(count).to.be.equal(1));
+      .reduce(count => count + 1, 0)
+      .then(count => expect(count).to.be.equal(1));
   });
   it('wait for the source stream to be finished emitting anything when no count is given', function() {
-    let count = 0;
     return most.iterate(x => x + 1, 0)
       .take(25)
       .thru(buffer())
-      .tap(() => { count += 1; })
       .tap(buffer => expect(buffer).to.have.lengthOf(25))
-      .drain()
-      .then(() => expect(count).to.be.equal(1));
+      .reduce(count => count + 1, 0)
+      .then(count => expect(count).to.be.equal(1));
   });
 });


### PR DESCRIPTION
`most-buffer` - It is now possible to not provide the `count` argument to buffer the full stream.

Objective -> get the same behavior than [Rx.Observable.toArray()](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-toArray).